### PR TITLE
chore: add copyright notice to concatImports

### DIFF
--- a/lib/core.nix
+++ b/lib/core.nix
@@ -46,6 +46,14 @@
   # Concatinatinates all file paths in a given directory into one list.
   # It recurses through subdirectories. If it detects a default.nix, only that
   # file will be considered.
+  #
+  # This function is copied from:
+  # https://github.com/yunfachi/nypkgs/blob/master/lib/umport.nix
+  #
+  # !!! REMOVING THIS NOTICE VIOLATES THE MIT LICENSE OF THE UMPORT PROJECT !!!
+  # This notice must be retained in all copies of this function, including modified versions!
+  # The MIT License can be found here:
+  # https://github.com/yunfachi/nypkgs/blob/master/LICENSE
   concatImports = {
     path ? null,
     paths ? [],


### PR DESCRIPTION
Hello, thank you for using umport! Could you please add the missing copyright notice to avoid violating the MIT License?